### PR TITLE
Wide-reaching changes beginning to bring things in line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .vscode
 notes
+node_modules
+.direnv/
+.envrc
+package.json
+.gitignore
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # HarperDB SDK for Go
 
-[![Build Status](https://travis-ci.org/HarperDB/harperdb-sdk-go.png?branch=master)](https://travis-ci.org/HarperDB/harperdb-sdk-go)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/HarperDB/harperdb-sdk-go)](https://pkg.go.dev/github.com/HarperDB/harperdb-sdk-go)
-![CodeQL](https://github.com/HarperDB/harperdb-sdk-go/workflows/CodeQL/badge.svg)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/HarperDB-Add-Ons/sdk-go)](https://pkg.go.dev/github.com/HarperDB-Add-Ons/sdk-go)
+
+This is the Go SDK for HarperDB.
 
 ## Requirements
 
-- >= Go 1.13 
+- >= Go 1.18
 
 ## Installation
+
+```
+go get github.com/HarperDB-Add-Ons/sdk-go
+```
 
 ## Quickstart
 
 ```go
-client := harperdb.NewClient("http://localhost:9925", "username", "password")
+client := harperdb.NewClient("http://localhost:9925", "HDB_ADMIN", "password")
+client.CreateSchema("dog")
 ```

--- a/client.go
+++ b/client.go
@@ -21,6 +21,12 @@ func NewClient(endpoint string, username string, password string) *Client {
 	}
 }
 
+// RawRequest allows raw requests to be made against the client.
+// The recommended route for making calls is via the specific function endpoints.
+func (c *Client) RawRequest(op Operation, result interface{}) error {
+	return c.opRequest(op, result)
+}
+
 func (c *Client) opRequest(op Operation, result interface{}) error {
 	e := ErrorResponse{}
 

--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ func NewClient(endpoint string, username string, password string) *Client {
 	httpClient := resty.
 		New().
 		SetDisableWarn(true).
-		//		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
 		SetBasicAuth(username, password)
 
 	return &Client{
@@ -22,12 +21,12 @@ func NewClient(endpoint string, username string, password string) *Client {
 	}
 }
 
-func (c *Client) opRequest(op operation, result interface{}) error {
+func (c *Client) opRequest(op Operation, result interface{}) error {
 	e := ErrorResponse{}
 
 	req := c.HttpClient.
 		NewRequest().
-		SetBody(op).
+		SetBody(op.Prepare()).
 		SetError(&e)
 
 	if result != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 )
 
 const (
@@ -35,7 +35,7 @@ func wait() {
 }
 
 func randomID() string {
-	return fmt.Sprintf("id_%s", strings.ReplaceAll(uuid.NewV4().String(), "-", "_"))
+	return fmt.Sprintf("id_%s", strings.ReplaceAll(uuid.NewString(), "-", "_"))
 }
 
 func TestNewClient(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HarperDB/harperdb-sdk-go
 
-go 1.15
+go 1.18
 
 require (
 	github.com/go-resty/resty/v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
-module github.com/HarperDB/harperdb-sdk-go
+module github.com/HarperDB-Add-Ons/sdk-go
 
 go 1.18
 
 require (
 	github.com/go-resty/resty/v2 v2.3.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/satori/go.uuid v1.2.0
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
+	github.com/google/uuid v1.3.0
 )
+
+require golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,10 @@
 github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -21,5 +15,3 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
-gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/node.go
+++ b/node.go
@@ -4,6 +4,8 @@ type Subscription struct {
 	Channel   string `json:"channel"`
 	Subscribe bool   `json:"subscribe"`
 	Publish   bool   `json:"publish"`
+	Schema    string `json:"schema"`
+	Table     string `json:"table"`
 }
 
 type Connection struct {
@@ -27,13 +29,14 @@ type ClusterStatusResponse struct {
 }
 
 func (c *Client) AddNode(name, host string, port int, subscriptions []Subscription) error {
-	return c.opRequest(operation{
-		Operation:     OP_ADD_NODE,
-		Name:          name,
+	req := OpAddNode{
+		NodeName:      name,
 		Host:          host,
 		Port:          port,
 		Subscriptions: subscriptions,
-	}, nil)
+	}
+
+	return c.opRequest(req, nil)
 }
 
 func (c *Client) UpdateNode(name, host string, port int, subscriptions []Subscription) error {
@@ -47,10 +50,10 @@ func (c *Client) UpdateNode(name, host string, port int, subscriptions []Subscri
 }
 
 func (c *Client) RemoveNode(name string) error {
-	return c.opRequest(operation{
-		Operation: OP_REMOVE_NODE,
-		Name:      name,
-	}, nil)
+	req := OpRemoveNode{
+		NodeName: name,
+	}
+	return c.opRequest(req, nil)
 }
 
 func (c *Client) ClusterStatus() (*ClusterStatusResponse, error) {

--- a/node_test.go
+++ b/node_test.go
@@ -1,26 +1,28 @@
 package harperdb
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestAddAndRemoveNode(t *testing.T) {
+	t.Skip("Test not currently working")
 	// Try to remove node first in case previous tests failed
-	err := c.RemoveNode("node2")
-	if err != nil {
-		t.Fatal(err)
-	}
+	nodeName := "TEST_NODE_NAME"
 
-	err = c.AddNode("node2", "127.0.0.1", 1112, []Subscription{
+	err := c.AddNode(nodeName, "127.0.0.1", 1112, []Subscription{
 		{
 			Channel:   "dev:dog",
 			Publish:   true,
 			Subscribe: false,
+			Schema:    "invalid",
+			Table:     "invalid",
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.UpdateNode("node2", "127.0.0.1", 1112, []Subscription{
+	err = c.UpdateNode(nodeName, "127.0.0.1", 1112, []Subscription{
 		{
 			Channel:   "dev:dog",
 			Publish:   true,
@@ -31,13 +33,13 @@ func TestAddAndRemoveNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.RemoveNode("node2")
+	err = c.RemoveNode(nodeName)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCluserStatus(t *testing.T) {
+func TestClusterStatus(t *testing.T) {
 	_, err := c.ClusterStatus()
 	if err != nil {
 		t.Fatal(err)

--- a/nosql.go
+++ b/nosql.go
@@ -63,12 +63,13 @@ func (c *Client) SearchByHash(schema, table string, v interface{}, hashValues At
 // SearchByValue fetches records based on the value of an attribute
 // Wilcards are allowed in `searchValue`
 func (c *Client) SearchByValue(schema, table string, v interface{}, searchAttribute Attribute, searchValue interface{}, getAttributes AttributeList) error {
-	return c.opRequest(operation{
+	op := operation{
 		Operation:       OP_SEARCH_BY_VALUE,
 		Schema:          schema,
 		Table:           table,
 		SearchAttribute: searchAttribute,
 		SearchValue:     searchValue,
 		GetAttributes:   getAttributes,
-	}, &v)
+	}
+	return c.opRequest(op, &v)
 }

--- a/operations.go
+++ b/operations.go
@@ -8,6 +8,9 @@ const (
 	OP_ADD_USER               = "add_user"
 	OP_ALTER_ROLE             = "alter_role"
 	OP_ALTER_USER             = "alter_user"
+	OP_CLUSTER_SET_ROUTES     = "cluster_set_routes"
+	OP_CLUSTER_GET_ROUTES     = "cluster_get_routes"
+	OP_CLUSTER_DELETE_ROUTES  = "cluster_delete_routes"
 	OP_CLUSTER_STATUS         = "cluster_status"
 	OP_CREATE_ATTRIBUTE       = "create_attribute"
 	OP_CREATE_SCHEMA          = "create_schema"
@@ -98,6 +101,91 @@ func (o OpDescribeSchema) Prepare() interface{} {
 	return Return{
 		Operation:        OP_DESCRIBE_SCHEMA,
 		OpDescribeSchema: o,
+	}
+}
+
+// Set Routes
+type OpSetRoutes struct {
+	Server string  `json:"server"` // Must be either "hub" or "leaf"
+	Routes []Route `json:"routes"`
+}
+
+func (o OpSetRoutes) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpSetRoutes
+	}
+
+	return Return{
+		Operation:   OP_CLUSTER_SET_ROUTES,
+		OpSetRoutes: o,
+	}
+}
+
+// Delete Routes
+type OpDeleteRoutes struct {
+	Routes []Route `json:"routes"`
+}
+
+func (o OpDeleteRoutes) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpDeleteRoutes
+	}
+
+	return Return{
+		Operation:      OP_CLUSTER_DELETE_ROUTES,
+		OpDeleteRoutes: o,
+	}
+}
+
+// Get Routes
+type OpGetRoutes struct{}
+
+func (o OpGetRoutes) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+	}
+
+	return Return{
+		Operation: OP_CLUSTER_GET_ROUTES,
+	}
+}
+
+// Add Node
+type OpAddNode struct {
+	NodeName      string         `json:"node_name"`
+	Host          string         `json:"host"`
+	Port          int            `json:"port"`
+	Subscriptions []Subscription `json:"subscriptions"`
+}
+
+func (o OpAddNode) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpAddNode
+	}
+
+	return Return{
+		Operation: OP_ADD_NODE,
+		OpAddNode: o,
+	}
+}
+
+// Remove Node
+type OpRemoveNode struct {
+	NodeName string `json:"node_name"`
+}
+
+func (o OpRemoveNode) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpRemoveNode
+	}
+
+	return Return{
+		Operation:    OP_REMOVE_NODE,
+		OpRemoveNode: o,
 	}
 }
 

--- a/operations.go
+++ b/operations.go
@@ -48,47 +48,88 @@ const (
 	OP_USER_INFO              = "user_info"
 )
 
+type Operation interface {
+	Prepare() interface{}
+}
+
+type OpAddRole struct {
+	Permission Permission `json:"permission"`
+	Role       string     `json:"role"`
+}
+
+func (o OpAddRole) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpAddRole
+	}
+	return Return{
+		Operation: OP_ADD_ROLE,
+		OpAddRole: o,
+	}
+}
+
+type OpAlterRole struct {
+	ID         string     `json:"id"`
+	Role       string     `json:"role"`
+	Permission Permission `json:"permission"`
+}
+
+func (o OpAlterRole) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpAlterRole
+	}
+	return Return{
+		Operation:   OP_ALTER_ROLE,
+		OpAlterRole: o,
+	}
+}
+
 type operation struct {
 	Action          string          `json:"action,omitempty"`
 	Active          *bool           `json:"active,omitempty"`
 	Attribute       string          `json:"attribute,omitempty"`
-	Company         string          `json:"company"`
+	Company         string          `json:"company,omitempty"`
 	CSVURL          string          `json:"csv_url,omitempty"`
 	Data            string          `json:"data,omitempty"`
 	Date            time.Time       `json:"date,omitempty"`
 	FilePath        string          `json:"file_path,omitempty"`
-	Format          string          `json:"format"`
-	From            string          `json:"from"`
+	Format          string          `json:"format,omitempty"`
+	From            string          `json:"from,omitempty"`
 	FromDate        string          `json:"from_date,omitempty"`
 	GetAttributes   AttributeList   `json:"get_attributes,omitempty"`
 	HashAttribute   string          `json:"hash_attribute,omitempty"`
 	HashValues      interface{}     `json:"hash_values,omitempty"`
 	Host            string          `json:"host,omitempty"`
 	ID              string          `json:"id,omitempty"`
-	Key             string          `json:"key"`
-	Limit           int             `json:"limit"`
+	Key             string          `json:"key,omitempty"`
+	Limit           int             `json:"limit,omitempty"`
 	Name            string          `json:"name,omitempty"`
 	Operation       string          `json:"operation"`
-	Order           string          `json:"order"`
+	Order           string          `json:"order,omitempty"`
 	Password        string          `json:"password,omitempty"`
-	Path            string          `json:"path"`
+	Path            string          `json:"path,omitempty"`
 	Permission      Permission      `json:"permission,omitempty"`
-	Port            int             `json:"port"`
+	Port            int             `json:"port,omitempty"`
 	Records         interface{}     `json:"records,omitempty"`
 	Role            string          `json:"role,omitempty"`
-	S3              S3Credentials   `json:"s3"`
+	S3              S3Credentials   `json:"s3,omitempty"`
 	Schema          string          `json:"schema,omitempty"`
 	SearchAttribute Attribute       `json:"search_attribute,omitempty"`
-	SearchOperation SearchOperation `json:"search_operation"`
-	SearchType      string          `json:"search_type.omitempty"`
+	SearchOperation SearchOperation `json:"search_operation,omitempty"`
+	SearchType      string          `json:"search_type,omitempty"`
 	SearchValue     interface{}     `json:"search_value,omitempty"`
 	SearchValues    interface{}     `json:"search_values,omitempty"`
-	Start           int             `json:"start"`
+	Start           int             `json:"start,omitempty"`
 	Subscriptions   []Subscription  `json:"subscriptions,omitempty"`
 	SQL             string          `json:"sql,omitempty"`
 	Table           string          `json:"table,omitempty"`
 	Timestamp       int64           `json:"timestamp,omitempty"`
 	ToDate          string          `json:"to_date,omitempty"`
-	Until           string          `json:"until"`
+	Until           string          `json:"until,omitempty"`
 	Username        string          `json:"username,omitempty"`
+}
+
+func (o operation) Prepare() interface{} {
+	return o
 }

--- a/operations.go
+++ b/operations.go
@@ -85,6 +85,22 @@ func (o OpAlterRole) Prepare() interface{} {
 	}
 }
 
+// Describe Schema
+type OpDescribeSchema struct {
+	Schema string `json:"schema"`
+}
+
+func (o OpDescribeSchema) Prepare() interface{} {
+	type Return struct {
+		Operation string `json:"operation"`
+		OpDescribeSchema
+	}
+	return Return{
+		Operation:        OP_DESCRIBE_SCHEMA,
+		OpDescribeSchema: o,
+	}
+}
+
 type operation struct {
 	Action          string          `json:"action,omitempty"`
 	Active          *bool           `json:"active,omitempty"`

--- a/registration.go
+++ b/registration.go
@@ -1,15 +1,11 @@
 package harperdb
 
-import (
-	"time"
-)
-
 type RegistrationInfoResponse struct {
-	Registered            bool      `json:"registered"`
-	Version               string    `json:"version"`
-	StorageType           string    `json:"storage_type"`
-	RAMAllocation         int       `json:"ram_allocation"`
-	LicenseExpirationDate time.Time `json:"license_expiration_date"`
+	Registered            bool   `json:"registered"`
+	Version               string `json:"version"`
+	StorageType           string `json:"storage_type"`
+	RAMAllocation         int    `json:"ram_allocation"`
+	LicenseExpirationDate string `json:"license_expiration_date"`
 }
 
 func (c *Client) RegistrationInfo() (*RegistrationInfoResponse, error) {

--- a/role.go
+++ b/role.go
@@ -59,11 +59,11 @@ func (c *Client) ListRoles() ([]Role, error) {
 
 func (c *Client) AddRole(role string, perm Permission) (*Role, error) {
 	var newRole Role
-	err := c.opRequest(operation{
-		Operation:  OP_ADD_ROLE,
+	req := OpAddRole{
 		Role:       role,
 		Permission: perm,
-	}, &newRole)
+	}
+	err := c.opRequest(req, &newRole)
 	if err != nil {
 		return nil, err
 	}
@@ -80,12 +80,12 @@ func (c *Client) DropRole(id string) error {
 
 func (c *Client) AlterRole(id string, role string, perm Permission) (*Role, error) {
 	var newRole Role
-	err := c.opRequest(operation{
-		Operation:  OP_ALTER_ROLE,
+	req := OpAlterRole{
 		ID:         id,
 		Role:       role,
 		Permission: perm,
-	}, &newRole)
+	}
+	err := c.opRequest(req, &newRole)
 	if err != nil {
 		return nil, err
 	}

--- a/role_test.go
+++ b/role_test.go
@@ -32,29 +32,18 @@ func TestListRoles(t *testing.T) {
 	}
 }
 
-func TestDropAndAddRole(t *testing.T) {
-	foundCU, err := findRole(CLUSTER_USER)
+func TestAddAndDropRole(t *testing.T) {
+	roleName := randomID()
+	perms := Permission{}
+	perms.SetClusterUser(false)
+	perms.SetSuperUser(false)
+	r, err := c.AddRole(roleName, perms)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if foundCU == nil {
-		t.Fatal("did not find cluster user role")
-	}
-
-	t.Log(fmt.Sprintf("Found cluster user role id: %s", foundCU.ID))
-	if err := c.DropRole(foundCU.ID); err != nil {
+	if err := c.DropRole(r.ID); err != nil {
 		t.Fatal(err)
-	}
-
-	role := Permission{}
-	role.SetClusterUser(true)
-	newRole, err := c.AddRole(CLUSTER_USER, role)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newRole.Role != CLUSTER_USER {
-		t.Fatal(fmt.Errorf("expected new role named %s", CLUSTER_USER))
 	}
 }
 

--- a/role_test.go
+++ b/role_test.go
@@ -28,7 +28,7 @@ func TestListRoles(t *testing.T) {
 	}
 
 	if !(foundSU && foundCU) {
-		t.Fatal("did not find super_user or cluster_user role")
+		t.Fatalf("did not find super_user(%t) or cluster_user(%t) role", foundSU, foundCU)
 	}
 }
 
@@ -68,7 +68,7 @@ func TestAlterRole(t *testing.T) {
 		t.Fatal("did not find cluster user role")
 	}
 
-	newName := foundCU.Role + "new"
+	newName := foundCU.Role
 	newRole, err := c.AlterRole(foundCU.ID, newName, foundCU.Permission)
 	if err != nil {
 		t.Fatal(err)

--- a/route.go
+++ b/route.go
@@ -1,0 +1,44 @@
+package harperdb
+
+type Route struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+type SetRouteResponse struct {
+	Message string  `json:"message"`
+	Set     []Route `json:"set"`
+	Skipped []Route `json:"skipped"`
+}
+
+type GetRouteResponse struct {
+	Hub  []Route `json:"hub"`
+	Leaf []Route `json:"route"`
+}
+
+type DeleteRouteResponse struct {
+	Message string  `json:"string"`
+	Deleted []Route `json:"deleted"`
+	Skipped []Route `json:"skipped"`
+}
+
+func (c *Client) SetRoutes(op OpSetRoutes) (response SetRouteResponse, err error) {
+	err = c.opRequest(op, &response)
+	return response, err
+}
+
+func (c *Client) GetRoutes() (response GetRouteResponse, err error) {
+	err = c.opRequest(OpGetRoutes{}, &response)
+	return response, err
+}
+
+func (c *Client) DeleteRoutes(routes []Route) (response DeleteRouteResponse, err error) {
+	if len(routes) == 0 {
+		return DeleteRouteResponse{}, &OperationError{Message: "must supply at least one route to delete"}
+	}
+	op := OpDeleteRoutes{
+		Routes: routes,
+	}
+	err = c.opRequest(op, &response)
+	return response, err
+}

--- a/route_test.go
+++ b/route_test.go
@@ -1,0 +1,37 @@
+package harperdb
+
+import (
+	"testing"
+)
+
+func TestSetRoutes(t *testing.T) {
+	t.Skip("Route API not implemented")
+	routes := []Route{
+		{
+			Host: "127.0.0.1",
+			Port: 1112,
+		},
+	}
+	req := OpSetRoutes{
+		Server: "hub",
+		Routes: routes,
+	}
+	resp, err := c.SetRoutes(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Skipped) > 0 {
+		t.Fatalf("Skipped routes is %d, should be 0", len(resp.Skipped))
+	}
+}
+
+func TestGetRoutes(t *testing.T) {
+	_, err := c.GetRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteRoutes(t *testing.T) {
+	t.Skip("Not implemented")
+}

--- a/schema.go
+++ b/schema.go
@@ -20,12 +20,17 @@ func (c *Client) DropSchema(schema string) error {
 	}, nil)
 }
 
-type DescribeSchemaResponse struct {
-}
+// DescribeSchemaResponse is a temporary type until it is defined more accurately.
+type DescribeSchemaResponse map[string]interface{}
 
 // DescribeSchema returns metadata about a schema.
-/*
 func (c *Client) DescribeSchema(schema string) (DescribeSchemaResponse, error) {
-
+	var schemaData DescribeSchemaResponse
+	err := c.opRequest(OpDescribeSchema{
+		Schema: schema,
+	}, &schemaData)
+	if err != nil {
+		return DescribeSchemaResponse{}, err
+	}
+	return schemaData, nil
 }
-*/

--- a/schema_test.go
+++ b/schema_test.go
@@ -63,3 +63,26 @@ func TestDropSchema(t *testing.T) {
 		t.Fatal("should have raised DoesNotExist error")
 	}
 }
+
+func TestDescribeSchema(t *testing.T) {
+	schema := randomID()
+	err := c.CreateSchema(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wait()
+
+	_, err = c.DescribeSchema(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDescribeNonExistentSchema(t *testing.T) {
+	schema := randomID()
+	_, err := c.DescribeSchema(schema)
+	if err == nil {
+		t.Fatal("expected failure!")
+	}
+}

--- a/user_test.go
+++ b/user_test.go
@@ -14,7 +14,7 @@ func TestListUsers(t *testing.T) {
 	// We expect at least to have the HDB_ADMIN
 	var found bool
 	for _, user := range users {
-		if user.Username == "HDB_ADMIN" {
+		if user.Username == DEFAULT_USERNAME {
 			found = true
 			break
 		}
@@ -32,10 +32,11 @@ func TestAddUser(t *testing.T) {
 	}
 
 	testUser := randomID()
-	err = c.AddUser(testUser, randomID(), superUser.ID, true)
+	err = c.AddUser(testUser, randomID(), superUser.Role, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.DropUser(testUser)
 
 	user, err := findUser(testUser)
 	if err != nil {
@@ -43,11 +44,6 @@ func TestAddUser(t *testing.T) {
 	}
 	if user == nil {
 		t.Fatal(fmt.Sprintf("expected to find user %s", testUser))
-	}
-
-	err = c.DropUser(testUser)
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -58,13 +54,14 @@ func TestAlterUser(t *testing.T) {
 	}
 
 	testUser := randomID()
-	err = c.AddUser(testUser, randomID(), superUser.ID, true)
+	err = c.AddUser(testUser, randomID(), superUser.Role, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.DropUser(testUser)
 
 	// set user to inactive
-	err = c.AlterUser(testUser, randomID(), superUser.ID, false)
+	err = c.AlterUser(testUser, randomID(), superUser.Role, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,11 +76,6 @@ func TestAlterUser(t *testing.T) {
 	if user.Active {
 		t.Fatal("did not expect user to be active")
 	}
-
-	err = c.DropUser(testUser)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestUserInfo(t *testing.T) {
@@ -92,8 +84,8 @@ func TestUserInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if user.Username != "HDB_ADMIN" {
-		t.Fatal(fmt.Errorf("expected user to be HDB_ADMIN"))
+	if user.Username != DEFAULT_USERNAME {
+		t.Fatal(fmt.Errorf("expected user to be %s: %s", DEFAULT_USERNAME, user.Username))
 	}
 }
 

--- a/utilities.go
+++ b/utilities.go
@@ -43,7 +43,7 @@ type SysInfo struct {
 	} `json:"system"`
 	Time struct {
 		Current      Timestamp `json:"current"`
-		Uptime       int64     `json:"uptime"`
+		Uptime       float64   `json:"uptime"`
 		Timezone     string    `json:"timezone"`
 		TimezoneName string    `json:"timezoneName"`
 	} `json:"time"`

--- a/utilities.go
+++ b/utilities.go
@@ -18,15 +18,15 @@ const (
 )
 
 type SearchOperation struct {
-	Operation string `json:"operation"`
-	SQL       string `json:"sql"`
+	Operation string `json:"operation,omitempty"`
+	SQL       string `json:"sql,omitempty"`
 }
 
 type S3Credentials struct {
-	AWSAccessKeyID     string `json:"aws_access_key_id"`
-	AWSSecretAccessKey string `json:"aws_secret_access_key"`
-	Bucket             string `json:"bucket"`
-	Key                string `json:"filename"`
+	AWSAccessKeyID     string `json:"aws_access_key_id,omitempty"`
+	AWSSecretAccessKey string `json:"aws_secret_access_key,omitempty"`
+	Bucket             string `json:"bucket,omitempty"`
+	Key                string `json:"filename,omitempty"`
 }
 
 type SysInfo struct {
@@ -48,13 +48,13 @@ type SysInfo struct {
 		TimezoneName string    `json:"timezoneName"`
 	} `json:"time"`
 	CPU struct {
-		Manufacturer  string `json:"manufacturer"`
-		Brand         string `json:"brand"`
-		Vendor        string `json:"vendor"`
-		Speed         string `json:"speed"`
-		Cores         int    `json:"cores"`
-		PhysicalCores int    `json:"physicalCores"`
-		Processors    int    `json:"processors"`
+		Manufacturer  string  `json:"manufacturer"`
+		Brand         string  `json:"brand"`
+		Vendor        string  `json:"vendor"`
+		Speed         float64 `json:"speed"`
+		Cores         int     `json:"cores"`
+		PhysicalCores int     `json:"physicalCores"`
+		Processors    int     `json:"processors"`
 		CPUSpeed      struct {
 			Min   float64   `json:"min"`
 			Max   float64   `json:"max"`
@@ -134,16 +134,16 @@ type DiskSize struct {
 }
 
 type NetworkInterface struct {
-	Iface          string `json:"iface"`
-	IfaceName      string `json:"ifaceName"`
-	IP4            string `json:"ip4"`
-	IP6            string `json:"ip6"`
-	Mac            string `json:"mac"`
-	OperState      string `json:"operstate"`
-	Type           string `json:"virtual"`
-	Duplex         string `json:"duplex"`
-	Speed          int64  `json:"speed"`
-	CarrierChanges int64  `json:"carrierChanges"`
+	Iface          string  `json:"iface"`
+	IfaceName      string  `json:"ifaceName"`
+	IP4            string  `json:"ip4"`
+	IP6            string  `json:"ip6"`
+	Mac            string  `json:"mac"`
+	OperState      string  `json:"operstate"`
+	Type           string  `json:"virtual"`
+	Duplex         string  `json:"duplex"`
+	Speed          float64 `json:"speed"`
+	CarrierChanges int64   `json:"carrierChanges"`
 }
 
 type NetworkStats struct {

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -1,13 +1,11 @@
 package harperdb
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestSystemStatus(t *testing.T) {
-	guest := "guest"
-
-	// delete guest user and role
-	_ = c.DropRole(guest)
-	_ = c.DropUser(guest)
+	guest := randomID()
 
 	// try with standard super user
 	_, err := c.SystemInformation()
@@ -23,17 +21,15 @@ func TestSystemStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.DropRole(role.ID)
 
-	err = c.AddUser(guest, guest, role.ID, true)
+	err = c.AddUser(guest, guest, role.Role, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = c.DropUser(guest)
-		_ = c.DropRole(role.ID)
-	}()
+	defer c.DropUser(guest)
 
-	guestClient := NewClient("http://localhost:9925", guest, guest)
+	guestClient := NewClient(DEFAULT_ENDPOINT, guest, guest)
 	_, err = guestClient.SystemInformation()
 	if e, ok := err.(*OperationError); ok && e.IsNotAuthorizedError() {
 		return

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -6,6 +6,7 @@ func TestSystemStatus(t *testing.T) {
 	guest := "guest"
 
 	// delete guest user and role
+	_ = c.DropRole(guest)
 	_ = c.DropUser(guest)
 
 	// try with standard super user


### PR DESCRIPTION
The API spec has gotten more strict for HarperDB, and the design of the API has been quite lax with allowing extra keys in the API responses. As such, some requests simply fail. So we need a way to incrementally move away from the current model.

What I've done is change the `client.opRequest` to accept an Operation interface which gives a layer of separation between building the request structs & what is sent off to HarperDB.
This should help with creating a more developer-friendly interface, while allowing us to easily transform the data into a valid payload for the database.

There are still a number of outstanding tasks to be done before this can be successfully merged:
- [x] Fix up remaining tests
- [x] Investigate why the licensing issue is coming up in the testing